### PR TITLE
Gitignore for user-input and egg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # User-supplied materials and generated state must never be committed.
+local-input/
+project_liminal_gate.egg-info/
 user-data/
 state/
 logs/


### PR DESCRIPTION
Gitignore should exclude the entire user-input folder and the egg-info generated 