### PR TITLE
Trust an incidental item drop on a Daily Quest instead of refusing the clear

### DIFF
--- a/liminal_gate/bootstrap_server.py
+++ b/liminal_gate/bootstrap_server.py
@@ -5450,6 +5450,14 @@ def _projected_hunting_items(
     retain whether a ticket was actually spent; ``None`` is limited to an
     already-active battle loaded from a pre-fix save. In every accepted case the
     returned inventory keeps the server's lower, already-charged ticket count.
+
+    A stage with ``allow_incidental_items`` (a Daily Quest) reaches here with
+    ``rewards`` that can include item IDs outside its own ``item_maxima`` --
+    ``hunting_settlement_within_bounds`` already let those through. Its own
+    declared items still project exactly, as below; every other slot instead
+    trusts the client the way an ordinary story clear's item list already does
+    (``_preserved_counts``): the reported count must be no lower than what is
+    already held, and is taken as-is rather than computed.
     """
     if not (
         isinstance(current, list)
@@ -5463,7 +5471,20 @@ def _projected_hunting_items(
     for item_id, count in rewards.items():
         if item_id > slots:
             return None
+        if stage.allow_incidental_items and item_id not in stage.item_maxima:
+            continue
         expected[item_id - 1] = min(maximum, expected[item_id - 1] + count)
+    if stage.allow_incidental_items:
+        declared_indices = {item_id - 1 for item_id in stage.item_maxima}
+        merged = list(expected)
+        for index in range(slots):
+            if index in declared_indices:
+                continue
+            reported = submitted[index]
+            if type(reported) is not int or not (0 <= reported <= maximum) or reported < merged[index]:
+                return None
+            merged[index] = reported
+        return merged if submitted == merged else None
     if submitted == expected:
         return expected
     if not stage.ticket_optional or ticket_spent is False:

--- a/liminal_gate/daily_quest_data.py
+++ b/liminal_gate/daily_quest_data.py
@@ -225,6 +225,12 @@ def build_bundled_daily_quest_stages() -> tuple[HuntingStage, ...]:
             max_items_total=max_items_total, item_maxima=dict(item_maxima),
             selector="hidden",
             once_per_utc_day=True,
+            # The same `drop_eligibility` roll every ordinary battle uses can
+            # hand back an item outside this quest's own themed reward chest.
+            # Only the chest itself is recovered and bounded below; an
+            # unrelated incidental item is trusted the way an ordinary story
+            # clear already trusts one, rather than refusing the whole clear.
+            allow_incidental_items=True,
             character_grants=(JOKER_LAMBDA_CHARACTER_ID,) if family == "the_hunt_for_joker" else (),
             duplicate_grant_skill_boost=_JOKER_DUPLICATE_SKILL_BOOST if family == "the_hunt_for_joker" else 0,
             duplicate_grant_luck=_JOKER_DUPLICATE_LUCK if family == "the_hunt_for_joker" else 0,

--- a/liminal_gate/hunting_catalog.py
+++ b/liminal_gate/hunting_catalog.py
@@ -84,6 +84,15 @@ class HuntingStage:
     #: greyed a played Daily Quest out using its own `lastDailyQuestPlayTime`
     #: fields; this server does not send those, so it enforces the limit itself.
     once_per_utc_day: bool = False
+    #: When true, an item outside `item_maxima` is accepted rather than
+    #: refusing the whole clear. Metal Zone, the Roads, and ordinary Hunting
+    #: have a fully recovered loot table, so an undeclared item there is
+    #: suspect and rejected. A Daily Quest only has its own themed reward
+    #: chest recovered; the same `drop_eligibility` roll that grants ordinary
+    #: story battles their incidental items applies here too, and rejecting an
+    #: otherwise-valid clear over one unrelated item is a worse answer than
+    #: trusting it the way an ordinary story clear already does.
+    allow_incidental_items: bool = False
 
     def identity_label(self) -> str:
         """The `chapter-section` string the client's selector lists expect."""
@@ -278,6 +287,14 @@ def hunting_settlement_within_bounds(stage: HuntingStage, result: dict[str, Any]
     that the labels beside their tables justify.  Battle Summons are refused
     everywhere, and battle-recruited monsters are refused everywhere except
     within a stage's declared `monster_recruit_maxima`.
+
+    Items are the one channel a `stage.allow_incidental_items` relaxes.  Every
+    stage's own declared items still bound to `item_maxima` and `max_items_total`
+    exactly as before; an item outside that declaration is refused unless the
+    stage opts in, which only a Daily Quest does.  Coins, EXP, Summons,
+    monsters, and Companions stay fully strict everywhere, Daily Quests
+    included, since those channels were never observed to carry an ordinary
+    battle's incidental reward the way items can.
     """
     if result["coins"] > stage.max_coins or result["exp"] > stage.max_exp:
         return False
@@ -292,9 +309,12 @@ def hunting_settlement_within_bounds(stage: HuntingStage, result: dict[str, Any]
     if stage.max_companions_total is not None and sum(companions.values()) > stage.max_companions_total:
         return False
     gained = {int(item_id): count for item_id, count in result["items"].items()}
-    if sum(gained.values()) > stage.max_items_total:
+    declared = {item_id: count for item_id, count in gained.items() if item_id in stage.item_maxima}
+    if not stage.allow_incidental_items and len(declared) != len(gained):
         return False
-    return all(item_id in stage.item_maxima and count <= stage.item_maxima[item_id] for item_id, count in gained.items())
+    if sum(declared.values()) > stage.max_items_total:
+        return False
+    return all(count <= stage.item_maxima[item_id] for item_id, count in declared.items())
 
 
 # The client's own inventory shape: 181 item counts, stacking to 999.

--- a/tests/test_daily_quests.py
+++ b/tests/test_daily_quests.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
+import json
+from http.client import HTTPConnection
+from pathlib import Path
+import tempfile
+import threading
 import unittest
+from unittest import mock
+from urllib.parse import urlencode
 
 from liminal_gate.daily_quest_data import (
     DAILY_QUEST_EPOCH_DAY,
@@ -11,10 +18,13 @@ from liminal_gate.daily_quest_data import (
     daily_quest_rotation,
 )
 from liminal_gate.bootstrap_server import (
+    BootstrapServer,
+    BootstrapState,
     _apply_hunting_character_grants,
     _daily_quest_played_today,
     _stamp_daily_quest_clear,
     daily_quest_login_fields,
+    load_profile,
 )
 from liminal_gate.hunting_catalog import HuntingCatalog, BUNDLED_ITEM_SLOTS, BUNDLED_MAX_STACK, hunting_settlement_within_bounds
 
@@ -103,9 +113,18 @@ class DailyQuestSettlementTest(unittest.TestCase):
         stage = self.stage(6006, 1)
         self.assertFalse(hunting_settlement_within_bounds(stage, result({80: 99})))
 
-    def test_an_unlisted_item_is_refused(self) -> None:
+    def test_an_incidental_item_outside_the_chest_settles(self) -> None:
+        """The same `drop_eligibility` roll every ordinary battle gets can hand
+        back an item outside a Daily Quest's own themed chest; refusing the
+        whole clear over that unrelated item was the bug -- see the greyed-out
+        Daily Quest menu reported from a real device."""
         stage = self.stage(6006, 1)
-        self.assertFalse(hunting_settlement_within_bounds(stage, result({1: 1})))
+        self.assertTrue(hunting_settlement_within_bounds(stage, result({80: 1, 1: 1})))
+
+    def test_the_chests_own_ceiling_still_refuses_regardless_of_incidental_items(self) -> None:
+        """Trusting an incidental item must not loosen the chest's own bound."""
+        stage = self.stage(6006, 1)
+        self.assertFalse(hunting_settlement_within_bounds(stage, result({80: 99, 1: 1})))
 
     def test_tropical_haze_settles_its_tickets(self) -> None:
         stage = self.stage(6007, 1)
@@ -329,3 +348,118 @@ class DailyQuestLoginTest(unittest.TestCase):
                 self.assertNotIn("lastDailyQuestPlayTime1", payload)
             finally:
                 server.shutdown(); thread.join(); server.server_close()
+
+
+class DailyQuestClearRuntimeTest(unittest.TestCase):
+    """A real clear over HTTP, reproducing the reported-from-device rejection.
+
+    A device reported a Daily Quest clearing with an extra item drop outside
+    its own recovered themed chest and getting `409
+    invalid_local_hunting_result` -- the same ordinary `drop_eligibility` roll
+    every other battle gets, refused here only because the chest's own bound
+    used to apply to every reported item rather than just its own.
+
+    `time.time` is patched to a fixed moment whose rotation is known (day
+    17816 offers Sweet Temptation, 6006-1) so entry does not depend on the day
+    the suite happens to run.
+    """
+
+    NOW = 1_539_302_400.0  # UTC day 17816; daily_quest_rotation(17816) includes 6006-1.
+
+    def setUp(self) -> None:
+        self.time_patcher = mock.patch("liminal_gate.bootstrap_server.time.time", return_value=self.NOW)
+        self.time_patcher.start()
+        self.addCleanup(self.time_patcher.stop)
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.token, self.account_id = "daily-token", "daily-account"
+        self.character = {
+            "id": 9001, "buddy": 0, "date": 0.0, "jobSlots": [0, 0, 0],
+            "jobLevels": [1, 0, 0], "jobID": 0, "flags": 0, "skillBoost": 0,
+        }
+        self.profile = load_profile(Path(__file__).resolve().parents[1] / "profiles" / "legacy-client-bootstrap.json")
+        catalog = HuntingCatalog(build_bundled_daily_quest_stages(), BUNDLED_ITEM_SLOTS, BUNDLED_MAX_STACK)
+        self.server = BootstrapServer(
+            ("127.0.0.1", 0), self.profile, BootstrapState(self.root / "state.json"),
+            hunting_catalog=catalog, daily_quests=True,
+        )
+        self.thread = threading.Thread(target=self.server.serve_forever)
+        self.thread.start()
+        self.server.state.create_account(self.token, self.account_id, {
+            "coins": 100, "energy": 40, "freeEnergy": 2, "worldMapNo": 0,
+            "progressCode": 0x01000000 | (2 << 6) | 1, "chrdata": [self.character],
+            "itemList": [0] * BUNDLED_ITEM_SLOTS, "summonList": [0, 0],
+        })
+        with self.server.state.lock:
+            account = self.server.state.accounts[self.account_id]
+            account["tutorial_phase"] = "free_roam"
+            account["initial_userdata_served"] = True
+            self.server.state._persist_locked()
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.thread.join()
+        self.server.server_close()
+        self.temporary_directory.cleanup()
+
+    def post(self, route: str, request_id: str, fields: list) -> tuple:
+        connection = HTTPConnection(*self.server.server_address)
+        connection.request(
+            "POST", f"{route}?otk={self.token}&requestID={request_id}",
+            body=urlencode(fields), headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response = connection.getresponse()
+        payload = json.loads(response.read())
+        connection.close()
+        return response.status, payload
+
+    def userdata(self) -> dict:
+        return json.loads((self.root / "state.json").read_text(encoding="utf-8"))["accounts"][self.account_id]["userdata"]
+
+    def start(self, request_id: str, chapter: int, section: int) -> tuple:
+        return self.post("/gd/start_quest", request_id, [
+            ("stamina", "0"), ("coins", "0"), ("chapter", str(chapter)),
+            ("section", str(section)), ("lastUpdate", "1"),
+        ])
+
+    def clear(self, request_id: str, chapter: int, section: int, *, items: dict) -> tuple:
+        userdata = self.userdata()
+        item_list = list(userdata["itemList"])
+        for item_id, count in items.items():
+            item_list[int(item_id) - 1] += count
+        return self.post("/gd/clear_quest", request_id, [
+            ("progressCode", str(userdata["progressCode"])), ("worldMapNo", "0"),
+            ("valuables", json.dumps({
+                "energyAppStore": 0, "energy": userdata["energy"], "energyAndApp": 0,
+                "freeEnergy": userdata["freeEnergy"], "energyGooglePlay": 0,
+                "coins": userdata["coins"],
+            })),
+            ("chrdata", json.dumps([self.character])),
+            ("itemList", json.dumps(item_list)),
+            ("summonList", json.dumps(userdata["summonList"])),
+            ("battle_result", json.dumps({
+                "chapter": chapter, "section": section, "coins": 0, "exp": 0,
+                "items": {str(k): v for k, v in items.items()}, "buddies": [], "monsters": [], "summons": [],
+                "luckynum": 0, "unableluckdrop": False, "boostup": [0, 0, 0, 0, 0, 0],
+            })),
+            ("itmp0", "0"), ("itmp1", "0"), ("lastUpdate", "1"),
+        ]), item_list
+
+    def test_an_incidental_drop_no_longer_blocks_the_clear(self) -> None:
+        """Sweet Temptation (6006-1) clears with its own Energy plus a stray item."""
+        status, started = self.start("daily-start", 6006, 1)
+        self.assertEqual((200, True), (status, started["success"]))
+
+        (status, cleared), item_list = self.clear("daily-clear", 6006, 1, items={80: 1, 1: 1})
+        self.assertEqual((200, True), (status, cleared["success"]), cleared)
+        self.assertEqual(item_list, self.userdata()["itemList"])
+
+    def test_the_chests_own_ceiling_still_refuses_over_http(self) -> None:
+        """The incidental item must not loosen Sweet Temptation's own bound."""
+        status, started = self.start("daily-over-start", 6006, 1)
+        self.assertEqual((200, True), (status, started["success"]))
+        before = self.userdata()
+
+        (status, refused), _ = self.clear("daily-over-clear", 6006, 1, items={80: 99, 1: 1})
+        self.assertEqual((409, "invalid_local_hunting_result"), (status, refused["error"]))
+        self.assertEqual(before, self.userdata())


### PR DESCRIPTION
## Summary

Reported from a real device (emulator, v1.0.3): clearing a Daily Quest with two item drops — one outside the quest's own themed reward chest — got `409 invalid_local_hunting_result` on `/gd/clear_quest`, surfaced to the player as a generic Network Error.

Daily Quests reuse `hunting_settlement_within_bounds`, whose all-or-nothing item rule is correct for Metal Zone, the Roads, and ordinary Hunting: their loot tables are fully recovered from BattleData, so an item outside the declared set really is an unbounded claim and refusing it is the right call. A Daily Quest only has its own themed chest recovered, not the incidental items the same `drop_eligibility` roll every ordinary battle gets. Ordinary story clears already trust that roll via `_preserved_counts` (`max(held, reported)` per slot); a Daily Quest's incidental items deserve the same trust rather than voiding an otherwise-valid clear over one unrelated item.

## Change

- `HuntingStage` gains `allow_incidental_items` (default `False`, so Metal Zone/Roads/ordinary Hunting are unchanged — the operator-catalog JSON schema doesn't expose it either, same as `once_per_utc_day`/`character_grants`).
- `build_bundled_daily_quest_stages` sets it `True`.
- `hunting_settlement_within_bounds` only requires every reported item be declared when the stage doesn't opt in; the chest's own `item_maxima`/`max_items_total` still bound exactly as before regardless.
- `_projected_hunting_items` mirrors the split: declared chest items still project by the existing exact math, every other slot merges by the same held/reported rule an ordinary story clear already uses.
- Coins, EXP, Summons, monster recruits, and Companions are untouched and stay fully strict everywhere, Daily Quests included — nothing suggested those channels carry an ordinary battle's incidental reward the way items can.

## Tests

- Two bounds-level tests: an incidental item now settles; the chest's own ceiling still refuses regardless of an accompanying incidental item.
- A new `DailyQuestClearRuntimeTest` class: a full HTTP round trip (signup → start → clear) reproducing the reported rejection and confirming the fix, plus confirming the chest's own ceiling still refuses over HTTP. `time.time` is patched to a fixed, pre-computed UTC day so entry doesn't depend on which day the suite runs.
- Full repository test suite passes (`python3 -m unittest discover`, exit 0).

Rebased onto current `main` (through "Serve BreaSoul and the Five Emperors...").
