### PR TITLE
network: Launching Shin'en and Mutoh quests from free-roam result in a network error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,17 @@ run the command.
 
 ### Fixed
 
+- **Give Up during a Chapter-1100 World Map Special battle answered 409
+  instead of releasing it.** The observed abandon signal is the same minimal
+  `chrdata`+`lastUpdate` save an ordinary character-screen close sends, and
+  `allows_ordinary_userdata_write` treated it as a valid battle exit for the
+  story and Hunting phases but not for a World Map Special one — even though
+  `update_character_userdata`, the handler that actually releases the battle,
+  was already written to abandon all three. The save never reached it, so the
+  account was left answering `tutorial_state_conflict` on every subsequent
+  request until the client was force-closed. World Map Special now sits in
+  that phase set alongside the other two.
+
 - **Half of every Companions of Truth pull was Healing Wand or Regen Bangle.**
   A tester counted it: *"most 10 pulls are like 5-6 of just those two items …
   a statistically unlikely amount"*. A second confirmed the shape of it from

--- a/liminal_gate/bootstrap_server.py
+++ b/liminal_gate/bootstrap_server.py
@@ -1156,6 +1156,7 @@ class BootstrapState:
             account = self.accounts.get(self.tokens.get(token))
             return account is not None and account.get("tutorial_phase") in {
                 "free_roam", "generic_story_active", "hunting_active",
+                "world_map_special_active",
             }
 
     def userdata_for(

--- a/tests/test_world_map_special.py
+++ b/tests/test_world_map_special.py
@@ -201,6 +201,20 @@ class WorldMapSpecialRuntimeTest(unittest.TestCase):
         # A repeatable Road pays no preservation Energy; see `archive_economy`.
         self.assertEqual(2, self.userdata()["freeEnergy"])
 
+    def test_give_up_releases_an_active_chapter_1100_battle(self) -> None:
+        """The same minimal chrdata save that abandons a story or Hunting run
+        must also abandon a World Map Special one, not answer 409.
+        """
+        self.assertEqual(200, self.start("wms-start", SHINEN_FIRST)[0])
+        self.assertEqual("world_map_special_active", self.phase())
+
+        status, given_up = self.post("/gd/userdata", "wms-give-up", [
+            ("chrdata", json.dumps([self.character])), ("lastUpdate", "1"),
+        ])
+        self.assertEqual((200, True), (status, given_up["success"]))
+        self.assertEqual("free_roam", self.phase())
+        self.assertIsNone(self.account().get("active_world_map_special"))
+
     def test_a_chapter_1100_battle_grows_luck(self) -> None:
         """25 stamina is well past Mistwalker's eight-stamina gate, and this
         handler rolled no table at all until the Luck family gap was closed.


### PR DESCRIPTION
allows_ordinary_userdata_write only treated free_roam, generic_story_active, and hunting_active as valid exits for the plain chrdata+lastUpdate save the client sends on Give Up, so that save was never routed to update_character_userdata during a Chapter-1100 battle and the account was stuck answering 409 tutorial_state_conflict instead of releasing back to free_roam.

Both deployments: dedicated server restart, and an APK rebuild for on-device testers, since bootstrap_server.py is the same server code in both. No catalog regeneration.